### PR TITLE
make installable and import version

### DIFF
--- a/maskfill/__init__.py
+++ b/maskfill/__init__.py
@@ -1,0 +1,1 @@
+from .maskfill import *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "maskfill"
+version = "0.1.0"
+description = "A Python package for image mask filling"
+authors = [
+    { name = "Pieter van Dokkum", email = "pieter.vandokkum@example.com" }
+]
+license = { file = "LICENSE" }
+readme = "README.md"
+requires-python = ">=3.6"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10"
+]
+dependencies = [
+    "numpy",
+    "astropy"
+]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='maskfill',  # Package name
+    version='0.1.0',  # Initial version
+    author='Pieter van Dokkum',  # Replace with your name
+    author_email='pieter.vandokkum@example.com',  # Replace with your email
+    description='A Python package for image mask filling',  # Replace with your description
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
+    url='https://github.com/dokkum/maskfill',  # Replace with the URL to your repo
+    packages=find_packages(),
+    install_requires=[
+        'numpy',
+        'astropy',  # Add other dependencies as needed
+    ],
+    entry_points={
+        'console_scripts': [
+            'maskfill=maskfill.maskfill:cli',
+        ],
+    },
+    classifiers=[
+        # Intended audience, project status, license, supported Python versions, etc.
+        # Example:
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+    ],
+)


### PR DESCRIPTION
Hi @dokkum. Here is a pull request (suggested updates) to the code that does a few things: 

1. Makes it locally pip-installable so that users can import `maskfill` from any python script. 
2. Adds a `maskfill` function that does the same thing but using python inputs, such that the code can be used within a python script
3. Makes the inputs either arrays *or* paths to fits files

(Note that the code can still be used from the command line using the argparse method). 